### PR TITLE
adopted better age calculation codes for tSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ The following instructions are for extracting cohort and generating final report
       ii) clone the AKI_CDM repository by typing command line: `$ git clone https://github.com/kumc-bmi/AKI_CDM`  
 
 
-2. Prepare configeration file `config.csv` and save alongside the AKI_CDM project folder    
-      i) **download** the `config_<DBMS_type>_example.csv` file according to `DBMS_type`
-      ii) **fill in** the content accordingly (or you can manually create the file using the following format)
+2. Prepare configeration file `config.csv` and save in the AKI_CDM project folder    
+      i) **download** the `config_<DBMS_type>_example.csv` file according to `DBMS_type`      
+      ii) **fill in** the content accordingly (or you can manually create the file using the following format)      
     
     |username     |password    |access         |cdm_db_name/sid                 |cdm_db_schema      |temp_db_schema |   
     |:------------|:-----------|:--------------|:-------------------------------|:------------------|:--------------|    
@@ -138,4 +138,4 @@ It takes about **1 ~ 1.5 hours** to complete Part I (AKI_CDM_EXT_VALID_p1_QA.Rmd
 
 
 ***
-*updated 09/24/2018*
+*updated 09/26/2018*

--- a/inst/tSQL/cohort_all_SCr.sql
+++ b/inst/tSQL/cohort_all_SCr.sql
@@ -34,7 +34,7 @@ group by l.PATID,l.ENCOUNTERID,l.LAB_ORDER_DATE,
 select distinct
        sa.PATID
       ,sa.ENCOUNTERID
-      ,datediff(yy,d.BIRTH_DATE,sa.LAB_ORDER_DATE) as age_at_Scr
+      ,(CONVERT(int,CONVERT(char(8),sa.LAB_ORDER_DATE,112))-CONVERT(int,CONVERT(char(8),d.BIRTH_DATE,112)))/10000 AS age_at_Scr
       ,case when d.SEX = 'F' then 1 else 0 end as female_ind 
       ,case when d.RACE = '03' then 1 else 0 end as race_aa_ind /*03=Black or African American*/
       ,sa.RESULT_NUM

--- a/inst/tSQL/cohort_initial.sql
+++ b/inst/tSQL/cohort_initial.sql
@@ -13,7 +13,7 @@ with age_at_admit as (
 select e.ENCOUNTERID
       ,e.PATID
       ,convert(datetime,convert(CHAR(8), e.ADMIT_DATE, 112)+ ' ' + CONVERT(CHAR(8), e.ADMIT_TIME, 108)) ADMIT_DATE_TIME
-      ,datediff(yy,d.BIRTH_DATE,d.ADMIT_DATE) as age_at_admit
+      ,(CONVERT(int,CONVERT(char(8),d.ADMIT_DATE,112))-CONVERT(int,CONVERT(char(8),d.BIRTH_DATE,112)))/10000 AS age_at_admit
       ,convert(datetime,convert(CHAR(8), e.DISCHARGE_DATE, 112)+ ' ' + CONVERT(CHAR(8), e.DISCHARGE_TIME, 108)) DISCHARGE_DATE_TIME
       ,round(datediff(dd,e.ADMIT_DATE,e.DISCHARGE_DATE),0) LOS
       ,e.ENC_TYPE

--- a/inst/tSQL/collect_demo.sql
+++ b/inst/tSQL/collect_demo.sql
@@ -13,7 +13,7 @@ select distinct
        pat.PATID
       ,pat.ENCOUNTERID
       ,demo.BIRTH_DATE
-      ,datediff(yy,demo.BIRTH_DATE,pat.ADMIT_DATE) as AGE
+      ,(CONVERT(int,CONVERT(char(8),pat.ADMIT_DATE,112))-CONVERT(int,CONVERT(char(8),demo.BIRTH_DATE,112)))/10000 AS AGE
       ,demo.SEX
       ,demo.RACE
       ,demo.HISPANIC


### PR DESCRIPTION
correct the calculation of ages in inst/tSQL/
    - "cohort_initial.sql": (CONVERT(int,CONVERT(char(8),d.ADMIT_DATE,112))-CONVERT(int,CONVERT(char(8),d.BIRTH_DATE,112)))/10000 AS age_at_admit
    - "cohort_all_SCr.sql": (CONVERT(int,CONVERT(char(8),sa.LAB_ORDER_DATE,112))-CONVERT(int,CONVERT(char(8),d.BIRTH_DATE,112)))/10000 AS age_at_Scr
    - "collect_demo.sql": (CONVERT(int,CONVERT(char(8),pat.ADMIT_DATE,112))-CONVERT(int,CONVERT(char(8),demo.BIRTH_DATE,112)))/10000 AS AGE