### PR TITLE
corrected logics for collecting initial SCr within an encounter when matching on (patient, day)

### DIFF
--- a/inst/Oracle/cohort_all_SCr.sql
+++ b/inst/Oracle/cohort_all_SCr.sql
@@ -57,7 +57,6 @@ select distinct
                'YYYY:MM:DD HH24:MI') SPECIMEN_DATE_TIME
       ,to_date(to_char(RESULT_DATE,'YYYY:MM:DD') || ' ' || to_char(RESULT_TIME),
                'YYYY:MM:DD HH24:MI') RESULT_DATE_TIME
-      ,dense_rank() over (partition by ENCOUNTERID order by RESULT_DATE, RESULT_TIME) rn
 from Scr_w_age
 where age_at_Scr >= 18
 

--- a/inst/tSQL/cohort_all_SCr.sql
+++ b/inst/tSQL/cohort_all_SCr.sql
@@ -58,7 +58,6 @@ select PATID
       ,convert(datetime, 
                convert(CHAR(8), RESULT_DATE, 112)+ ' ' + CONVERT(CHAR(8), RESULT_TIME, 108)
                ) RESULT_DATE_TIME
-      ,dense_rank() over (partition by ENCOUNTERID order by RESULT_DATE, RESULT_TIME) rn
 into #All_Scr_eGFR
 from Scr_w_age
 where age_at_Scr >= 18

--- a/inst/tSQL/cohort_enc_SCr.sql
+++ b/inst/tSQL/cohort_enc_SCr.sql
@@ -7,10 +7,11 @@
 /*
 /*action: write
 /********************************************************************************/
-select scr.* 
+select scr.*  
+      ,dense_rank() over (partition by PATID order by LAB_ORDER_DATE,SPECIMEN_DATE_TIME) rn
 into #AKI_Scr_eGFR
 from #All_Scr_eGFR scr
 where exists (select 1 from #AKI_Initial aki where scr.ENCOUNTERID = aki.ENCOUNTERID) or
-      exists (select 1 from #AKI_Initial aki where scr.PATID = aki.PATID and scr.LAB_ORDER_DATE between aki.ADMIT_DATE and aki.DISCHARGE_DATE)
+      exists (select 1 from #AKI_Initial aki where scr.PATID = aki.PATID and scr.LAB_ORDER_DATE between aki.ADMIT_DATE_TIME and aki.DISCHARGE_DATE)
 
 

--- a/inst/tSQL/cohort_enc_SCr.sql
+++ b/inst/tSQL/cohort_enc_SCr.sql
@@ -7,11 +7,34 @@
 /*
 /*action: write
 /********************************************************************************/
-select scr.*  
-      ,dense_rank() over (partition by PATID order by LAB_ORDER_DATE,SPECIMEN_DATE_TIME) rn
-into #AKI_Scr_eGFR
+with multi_match as (
+select scr.*
 from #All_Scr_eGFR scr
-where exists (select 1 from #AKI_Initial aki where scr.ENCOUNTERID = aki.ENCOUNTERID) or
-      exists (select 1 from #AKI_Initial aki where scr.PATID = aki.PATID and scr.LAB_ORDER_DATE between aki.ADMIT_DATE_TIME and aki.DISCHARGE_DATE)
+where exists (select 1 from #AKI_Initial aki where scr.ENCOUNTERID = aki.ENCOUNTERID)
+union all
+select aki.PATID
+      ,aki.ENCOUNTERID
+      ,scr.SERUM_CREAT
+      ,scr.eGFR
+      ,scr.LAB_ORDER_DATE
+      ,scr.SPECIMEN_DATE_TIME
+      ,scr.RESULT_DATE_TIME
+from #All_Scr_eGFR scr
+join #AKI_Initial aki
+on scr.PATID = aki.PATID and scr.ENCOUNTERID <> aki.ENCOUNTERID and
+   scr.LAB_ORDER_DATE between aki.ADMIT_DATE_TIME and aki.DISCHARGE_DATE_TIME
+)
+select distinct
+       mm.PATID
+      ,mm.ENCOUNTERID
+      ,mm.SERUM_CREAT
+      ,mm.eGFR
+      ,mm.LAB_ORDER_DATE
+      ,mm.SPECIMEN_DATE_TIME
+      ,mm.RESULT_DATE_TIME
+      ,dense_rank() over (partition by mm.ENCOUNTERID order by mm.LAB_ORDER_DATE,mm.SPECIMEN_DATE_TIME) rn      
+into #AKI_Scr_eGFR
+from multi_match mm
+
 
 

--- a/test/test_execute_sql.R
+++ b/test/test_execute_sql.R
@@ -1,9 +1,9 @@
 #### test execute_..._sql() ####
 source("./R/util.R")
 require_libraries(c("DBI",
+                    "magrittr",
                     "tidyr",
                     "dplyr",
-                    "magrittr",
                     "stringr"))
 
 params<-list(  DBMS_type="Oracle",
@@ -72,4 +72,14 @@ execute_batch_sql(conn,statements,verb=T,
                   cdm_db_schema=cdm_db_schema,
                   start_date=start_date,
                   end_date=end_date)
+#passed!
+
+
+####consort table
+#collect attrition info
+sql<-parse_sql(paste0("./inst/",DBMS_type,"/consort_diagram.sql"))
+attrition<-execute_single_sql(conn,
+                              statement=sql$statement,
+                              write=(sql$action=="write"),
+                              table_name=toupper(sql$tbl_out))
 #passed!


### PR DESCRIPTION
creatinine is now collected based on either matching on ENCOUNTERID or PATID+within (ADMI_DATE_TIME, DISCHARGE_DATE_TIME)